### PR TITLE
Fix bug ticket matcher

### DIFF
--- a/Events/Discord/MessageEvents.cs
+++ b/Events/Discord/MessageEvents.cs
@@ -31,7 +31,7 @@ namespace DisCatSharp.Support.Events.Discord
             {
                 if (true)//e.Guild.Id == Bot.Config.DiscordConfig.ApplicationCommandConfig.Dcs.GuildId)
                 {
-                    Regex reg = new(@"(?:https:\/\/bugs.aitsys.dev\/T(\d{1,4)|(?:T)(\d{1,4}))");
+                    Regex reg = new(@"\b(?:https:\/\/(?:bugs\.)?aitsys\.dev\/T(\d{1,4)|(?:T)(\d{1,4}))\b");
                     Match match = reg.Match(e.Message.Content);
                     if (match.Success)
                     {


### PR DESCRIPTION
Use \b to explicitly match on word boundaries.
This prevents matching things like "1234-12-12T12:12:12" and "aBcT1u" - "T12:asd" will still match as ":" counts as a boundary.

At the same time I turned the "bugs." part of the URL matcher optional, as the domain changed from sub domain to secondlevel domain.